### PR TITLE
Change demo to use Apache Cassandra

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Fault Tolerant Applications with DataStax and Apache Cassandra™ Demo
+# Fault Tolerant Applications with Apache Cassandra™ Demo
 
-Demo project to provision and deploy a multitier application architecture that is resilient to infrastructure outages
-at Availability Zone and Region level using DataStax and Apache Cassandra™.
+Demo project to provision and deploy a multi-tier application architecture that is resilient to infrastructure outages
+at Availability Zone and Region level using Cassandra.
 
 ## Table of contents
 
@@ -21,7 +21,7 @@ provider and see how it behaves during those outages, while handling incoming lo
 
 The following services are created as part of this demo:
 
-- 6 EC2 instances for [DataStax Distribution of Apache Cassandra][ddac] nodes segregated in two data-centers:
+- 6 EC2 instances for Cassandra nodes segregated in two data-centers:
     - Region us-east-1: 3 EC2 `m5.2xlarge` instances across 3 Availability Zones (AZ). 
     - Region us-west-2: 3 EC2 `m5.2xlarge` instances across 3 AZs.
 - 6 EC2 `m5.large` instances to be used for application services, one in each AZ.
@@ -38,7 +38,7 @@ for more information.
 
 ![Architecture diagram](https://i.imgur.com/N2OKUZ2.png)
 
-_Note that each web instance connects to all the Apache Cassandra nodes within the region, regardless of the AZ._
+_Note that each web instance connects to all the Cassandra nodes within the region, regardless of the AZ._
 
 ## Schema and Queries
 ### Schema
@@ -79,9 +79,11 @@ on AWS is around $10 per hour.
 
 ### Packer images
 
+Expect building the images to take several minutes.
 To build the images on the different regions use:
 
 ```bash
+cd dc-failover-demo
 packer build ./packer/template.json
 ```
 
@@ -90,7 +92,8 @@ packer build ./packer/template.json
 To create the instances and services use:
 
 ```bash
-terraform apply ./terraform/
+cd dc-failover-demo/terraform
+terraform apply
 ```
 
 ### Verify
@@ -151,7 +154,7 @@ terraform destroy \
 
 As a result, for new incoming requests the load balancer will route traffic to service instances in the
 healthy zones. Application service instances using Apache Cassandra nodes from AZs that were not impacted will not 
-experience errors derived from the loss of connectivity to the failed nodes and the DataStax Drivers will attempt to
+experience errors derived from the loss of connectivity to the failed nodes and the drivers will attempt to
 reconnect in the background while using the set of live nodes as coordinators for the queries while the failed nodes
 are offline.
 
@@ -174,6 +177,13 @@ region. Application services that are healthy can continue querying the database
 
 Note that Global Accelerator will take ten seconds to identify a target as unhealthy.
 
+### Cleanup
+**Confirm only the demo resources will be destroyed before executing**
+
+Cleanup all terraform managed resources with:
+```bash
+terraform destroy
+```
 ## Notice
 
 The source code contained in this project is designed for demonstration purposes and it's not intended for production
@@ -185,7 +195,6 @@ securily.
 The software is provided "as is", without warranty of any kind.  Any use by you of the source 
 code is at your own risk.
 
-[ddac]: https://www.datastax.com/products/datastax-distribution-of-apache-cassandra
 [aws-vault]: https://github.com/99designs/aws-vault
 [aws-okta]: https://github.com/segmentio/aws-okta
 [okta]: https://www.okta.com/

--- a/README.md
+++ b/README.md
@@ -77,23 +77,29 @@ and client load testing tool is deployed using [Packer][packer] images.
 Note that images, instances and services created on AWS have an associated cost. Estimated cost of running this demo 
 on AWS is around $10 per hour.
 
+### Clone the repository
+
+```bash
+git clone git@github.com:datastax/dc-failover-demo.git
+cd dc-failover-demo
+```
+
 ### Packer images
 
-Expect building the images to take several minutes.
 To build the images on the different regions use:
 
 ```bash
-cd dc-failover-demo
 packer build ./packer/template.json
 ```
+
+Expect building the images to take several minutes.
 
 ### Terraform
 
 To create the instances and services use:
 
 ```bash
-cd dc-failover-demo/terraform
-terraform apply
+terraform apply ./terraform/
 ```
 
 ### Verify
@@ -178,12 +184,13 @@ region. Application services that are healthy can continue querying the database
 Note that Global Accelerator will take ten seconds to identify a target as unhealthy.
 
 ### Cleanup
-**Confirm only the demo resources will be destroyed before executing**
 
-Cleanup all terraform managed resources with:
+You can cleanup all terraform managed resources with:
+
 ```bash
-terraform destroy
+terraform destroy ./terraform/
 ```
+
 ## Notice
 
 The source code contained in this project is designed for demonstration purposes and it's not intended for production

--- a/packer/scripts/cassandra/download_install.sh
+++ b/packer/scripts/cassandra/download_install.sh
@@ -7,5 +7,5 @@ sudo apt-get install -y cloud-utils
 sudo apt-get install -y python-dev python-setuptools python-yaml
 
 # download and uncompress Cassandra
-wget -c https://downloads.datastax.com/ddac/ddac-bin.tar.gz -O - | tar -xz
+mkdir cassandra; wget -c http://apache.spinellicreations.com/cassandra/4.0-alpha4/apache-cassandra-4.0-alpha4-bin.tar.gz -O - | tar -xz -C cassandra --strip-components=1
 

--- a/packer/scripts/cassandra/download_install.sh
+++ b/packer/scripts/cassandra/download_install.sh
@@ -7,5 +7,5 @@ sudo apt-get install -y cloud-utils
 sudo apt-get install -y python-dev python-setuptools python-yaml
 
 # download and uncompress Cassandra
-mkdir cassandra; wget -c http://apache.spinellicreations.com/cassandra/4.0-alpha4/apache-cassandra-4.0-alpha4-bin.tar.gz -O - | tar -xz -C cassandra --strip-components=1
+mkdir cassandra; wget -c http://archive.apache.org/dist/cassandra/4.0-alpha4/apache-cassandra-4.0-alpha4-bin.tar.gz -O - | tar -xz -C cassandra --strip-components=1
 

--- a/packer/scripts/cassandra/generate_config.sh
+++ b/packer/scripts/cassandra/generate_config.sh
@@ -9,15 +9,15 @@ export REGION=$(echo $AZ | sed 's/.$//')
 export PRIVATE_IP=$(ec2metadata --local-ipv4)
 
 # Replace cassandra.yaml file
-cp cassandra.yaml ddac-*/conf/
+cp cassandra.yaml cassandra/conf/
 
-cd ddac-*/conf
+cd cassandra/conf
 
 # Set DC and RACK on cassandra-rackdc.properties
 printf 'dc=%s\nrack=%s\n' $REGION $AZ > cassandra-rackdc.properties
 
 # Remove cassandra-topology.properties file
-rm -f ddac-*/conf/cassandra-topology.properties
+rm -f cassandra/conf/cassandra-topology.properties
 
 # Set seeds and listen address
 printf '\nlisten_address: "%s"' $PRIVATE_IP >> cassandra.yaml

--- a/packer/scripts/client/install_client.sh
+++ b/packer/scripts/client/install_client.sh
@@ -7,4 +7,4 @@ sudo apt-get install -y cloud-utils
 sudo apt-get install -y python-dev python-setuptools python-yaml python-pip
 
 # install locust
-sudo pip install 'locustio<1.0'
+sudo pip install 'locustio==0.13.5'

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <mainClass>com.datastax.demo.DemoServiceApplication</mainClass>
         <dropwizard.version>1.3.12</dropwizard.version>
-        <driver.version>4.0.1</driver.version>
+        <driver.version>4.5.1</driver.version>
     </properties>
 
     <dependencyManagement>

--- a/terraform/elb.tf
+++ b/terraform/elb.tf
@@ -1,19 +1,19 @@
 # Region 1 ELB
 
-resource "aws_lb" "lb_r1" {
-  provider = "aws.region1"
+resource aws_lb lb_r1 {
+  provider = aws.region1
   load_balancer_type = "application"
-  subnets = ["${aws_subnet.r1_az1.id}", "${aws_subnet.r1_az2.id}", "${aws_subnet.r1_az3.id}"]
-  security_groups = ["${aws_security_group.sg_default_r1.id}", "${aws_security_group.sg_elb_r1.id}"]
+  subnets = [aws_subnet.r1_az1.id, aws_subnet.r1_az2.id, aws_subnet.r1_az3.id]
+  security_groups = [aws_security_group.sg_default_r1.id, aws_security_group.sg_elb_r1.id]
   enable_cross_zone_load_balancing = true
   internal = false
 }
 
-resource "aws_lb_target_group" "lb_tg_r1" {
-  provider = "aws.region1"
+resource aws_lb_target_group lb_tg_r1 {
+  provider = aws.region1
   port = 80
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.r1.id}"
+  vpc_id = aws_vpc.r1.id
   target_type = "instance"
 
   health_check {
@@ -26,55 +26,55 @@ resource "aws_lb_target_group" "lb_tg_r1" {
   }
 }
 
-resource "aws_lb_listener" "lb_r1_listener" {
-  provider = "aws.region1"
-  load_balancer_arn = "${aws_lb.lb_r1.arn}"
-  port = "80"
+resource aws_lb_listener lb_r1_listener {
+  provider = aws.region1
+  load_balancer_arn = aws_lb.lb_r1.arn
+  port = 80
   protocol = "HTTP"
 
   default_action {
     type = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_tg_r1.arn}"
+    target_group_arn = aws_lb_target_group.lb_tg_r1.arn
   }
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r1_i1" {
-  provider = "aws.region1"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r1.arn}"
-  target_id = "${aws_instance.i_web_r1_i1.id}"
+resource aws_lb_target_group_attachment lb_tga_r1_i1 {
+  provider = aws.region1
+  target_group_arn = aws_lb_target_group.lb_tg_r1.arn
+  target_id = aws_instance.i_web_r1_i1.id
   port = 8080
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r1_i2" {
-  provider = "aws.region1"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r1.arn}"
-  target_id = "${aws_instance.i_web_r1_i2.id}"
+resource aws_lb_target_group_attachment lb_tga_r1_i2 {
+  provider = aws.region1
+  target_group_arn = aws_lb_target_group.lb_tg_r1.arn
+  target_id = aws_instance.i_web_r1_i2.id
   port = 8080
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r1_i3" {
-  provider = "aws.region1"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r1.arn}"
-  target_id = "${aws_instance.i_web_r1_i3.id}"
+resource aws_lb_target_group_attachment lb_tga_r1_i3 {
+  provider = aws.region1
+  target_group_arn = aws_lb_target_group.lb_tg_r1.arn
+  target_id = aws_instance.i_web_r1_i3.id
   port = 8080
 }
 
 # Region 2 ELB
 
-resource "aws_lb" "lb_r2" {
-  provider = "aws.region2"
+resource aws_lb lb_r2 {
+  provider = aws.region2
   load_balancer_type = "application"
-  subnets = ["${aws_subnet.r2_az1.id}", "${aws_subnet.r2_az2.id}", "${aws_subnet.r2_az3.id}"]
-  security_groups = ["${aws_security_group.sg_default_r2.id}", "${aws_security_group.sg_elb_r2.id}"]
+  subnets = [aws_subnet.r2_az1.id, aws_subnet.r2_az2.id, aws_subnet.r2_az3.id]
+  security_groups = [aws_security_group.sg_default_r2.id, aws_security_group.sg_elb_r2.id]
   enable_cross_zone_load_balancing = true
   internal = false
 }
 
-resource "aws_lb_target_group" "lb_tg_r2" {
-  provider = "aws.region2"
+resource aws_lb_target_group lb_tg_r2 {
+  provider = aws.region2
   port = 80
   protocol = "HTTP"
-  vpc_id = "${aws_vpc.r2.id}"
+  vpc_id = aws_vpc.r2.id
   target_type = "instance"
 
   health_check {
@@ -87,35 +87,35 @@ resource "aws_lb_target_group" "lb_tg_r2" {
   }
 }
 
-resource "aws_lb_listener" "lb_r2_listener" {
-  provider = "aws.region2"
-  load_balancer_arn = "${aws_lb.lb_r2.arn}"
-  port = "80"
+resource aws_lb_listener lb_r2_listener {
+  provider = aws.region2
+  load_balancer_arn = aws_lb.lb_r2.arn
+  port = 80
   protocol = "HTTP"
 
   default_action {
     type = "forward"
-    target_group_arn = "${aws_lb_target_group.lb_tg_r2.arn}"
+    target_group_arn = aws_lb_target_group.lb_tg_r2.arn
   }
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r2_i1" {
-  provider = "aws.region2"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r2.arn}"
-  target_id = "${aws_instance.i_web_r2_i1.id}"
+resource aws_lb_target_group_attachment lb_tga_r2_i1 {
+  provider = aws.region2
+  target_group_arn = aws_lb_target_group.lb_tg_r2.arn
+  target_id = aws_instance.i_web_r2_i1.id
   port = 8080
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r2_i2" {
-  provider = "aws.region2"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r2.arn}"
-  target_id = "${aws_instance.i_web_r2_i2.id}"
+resource aws_lb_target_group_attachment lb_tga_r2_i2 {
+  provider = aws.region2
+  target_group_arn = aws_lb_target_group.lb_tg_r2.arn
+  target_id = aws_instance.i_web_r2_i2.id
   port = 8080
 }
 
-resource "aws_lb_target_group_attachment" "lb_tga_r2_i3" {
-  provider = "aws.region2"
-  target_group_arn = "${aws_lb_target_group.lb_tg_r2.arn}"
-  target_id = "${aws_instance.i_web_r2_i3.id}"
+resource aws_lb_target_group_attachment lb_tga_r2_i3 {
+  provider = aws.region2
+  target_group_arn = aws_lb_target_group.lb_tg_r2.arn
+  target_id = aws_instance.i_web_r2_i3.id
   port = 8080
 }

--- a/terraform/global_accelerator.tf
+++ b/terraform/global_accelerator.tf
@@ -1,11 +1,11 @@
-resource "aws_globalaccelerator_accelerator" "demo_acc" {
+resource aws_globalaccelerator_accelerator demo_acc {
   name = "demo-accelerator-${random_id.id1.hex}"
   ip_address_type = "IPV4"
   enabled = true
 }
 
-resource "aws_globalaccelerator_listener" "demo_acc_listener" {
-  accelerator_arn = "${aws_globalaccelerator_accelerator.demo_acc.id}"
+resource aws_globalaccelerator_listener demo_acc_listener {
+  accelerator_arn = aws_globalaccelerator_accelerator.demo_acc.id
   protocol = "TCP"
 
   port_range {
@@ -14,9 +14,9 @@ resource "aws_globalaccelerator_listener" "demo_acc_listener" {
   }
 }
 
-resource "aws_globalaccelerator_endpoint_group" "demo_acc_eg_r1" {
-  provider = "aws.region1"
-  listener_arn = "${aws_globalaccelerator_listener.demo_acc_listener.id}"
+resource aws_globalaccelerator_endpoint_group demo_acc_eg_r1 {
+  provider = aws.region1
+  listener_arn = aws_globalaccelerator_listener.demo_acc_listener.id
   health_check_interval_seconds = 10
   threshold_count = 2
   health_check_path = "/status"
@@ -24,14 +24,14 @@ resource "aws_globalaccelerator_endpoint_group" "demo_acc_eg_r1" {
   health_check_protocol = "HTTP"
 
   endpoint_configuration {
-    endpoint_id = "${aws_lb.lb_r1.arn}"
+    endpoint_id = aws_lb.lb_r1.arn
     weight = 100
   }
 }
 
-resource "aws_globalaccelerator_endpoint_group" "demo_acc_eg_r2" {
-  provider = "aws.region2"
-  listener_arn = "${aws_globalaccelerator_listener.demo_acc_listener.id}"
+resource aws_globalaccelerator_endpoint_group demo_acc_eg_r2 {
+  provider = aws.region2
+  listener_arn = aws_globalaccelerator_listener.demo_acc_listener.id
   health_check_interval_seconds = 10
   threshold_count = 2
   health_check_path = "/status"
@@ -39,7 +39,7 @@ resource "aws_globalaccelerator_endpoint_group" "demo_acc_eg_r2" {
   health_check_protocol = "HTTP"
 
   endpoint_configuration {
-    endpoint_id = "${aws_lb.lb_r2.arn}"
+    endpoint_id = aws_lb.lb_r2.arn
     weight = 100
   }
 }

--- a/terraform/instances_bastion.tf
+++ b/terraform/instances_bastion.tf
@@ -3,14 +3,14 @@
 ### to the rest of the nodes in each region
 ##################################################
 
-resource "aws_instance" "bastion_r1" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.cassandra_r1.id}"
+resource aws_instance bastion_r1 {
+  provider = aws.region1
+  ami = data.aws_ami.cassandra_r1.id
   instance_type = "t2.small"
-  subnet_id = "${aws_subnet.r1_az1.id}"
+  subnet_id = aws_subnet.r1_az1.id
   associate_public_ip_address = true
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}", "${aws_security_group.sg_bastion_r1.id}"]
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id, aws_security_group.sg_bastion_r1.id]
   tags = {
     Name = "Demo - Bastion",
     Purpose = "Demo failover"

--- a/terraform/instances_cassandra_nodes.tf
+++ b/terraform/instances_cassandra_nodes.tf
@@ -2,13 +2,13 @@
 ### Rest of the Cassandra nodes
 ##################################
 
-resource "aws_instance" "i_cassandra_r1_i2" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.cassandra_r1.id}"
+resource aws_instance i_cassandra_r1_i2 {
+  provider = aws.region1
+  ami = data.aws_ami.cassandra_r1.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r1_az2.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az2.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -20,7 +20,7 @@ resource "aws_instance" "i_cassandra_r1_i2" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -32,19 +32,19 @@ resource "aws_instance" "i_cassandra_r1_i2" {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip},${aws_instance.i_cassandra_r2_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }
 }
 
-resource "aws_instance" "i_cassandra_r1_i3" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.cassandra_r1.id}"
+resource aws_instance i_cassandra_r1_i3 {
+  provider = aws.region1
+  ami = data.aws_ami.cassandra_r1.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r1_az3.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az3.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -59,7 +59,7 @@ resource "aws_instance" "i_cassandra_r1_i3" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -71,19 +71,19 @@ resource "aws_instance" "i_cassandra_r1_i3" {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip},${aws_instance.i_cassandra_r2_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }
 }
 
-resource "aws_instance" "i_cassandra_r2_i2" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.cassandra_r2.id}"
+resource aws_instance i_cassandra_r2_i2 {
+  provider = aws.region2
+  ami = data.aws_ami.cassandra_r2.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r2_az2.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r2.id}"]
+  subnet_id = aws_subnet.r2_az2.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r2.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -98,7 +98,7 @@ resource "aws_instance" "i_cassandra_r2_i2" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -110,19 +110,19 @@ resource "aws_instance" "i_cassandra_r2_i2" {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip},${aws_instance.i_cassandra_r2_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }
 }
 
-resource "aws_instance" "i_cassandra_r2_i3" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.cassandra_r2.id}"
+resource aws_instance i_cassandra_r2_i3 {
+  provider = aws.region2
+  ami = data.aws_ami.cassandra_r2.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r2_az3.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_r2_az3.id}"]
+  subnet_id = aws_subnet.r2_az3.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_r2_az3.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -137,7 +137,7 @@ resource "aws_instance" "i_cassandra_r2_i3" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -149,7 +149,7 @@ resource "aws_instance" "i_cassandra_r2_i3" {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip},${aws_instance.i_cassandra_r2_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }

--- a/terraform/instances_cassandra_seeds.tf
+++ b/terraform/instances_cassandra_seeds.tf
@@ -32,7 +32,7 @@ resource aws_instance i_cassandra_r1_i1 {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }

--- a/terraform/instances_cassandra_seeds.tf
+++ b/terraform/instances_cassandra_seeds.tf
@@ -2,13 +2,13 @@
 ### Cassandra seed nodes
 ##################################
 
-resource "aws_instance" "i_cassandra_r1_i1" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.cassandra_r1.id}"
+resource aws_instance i_cassandra_r1_i1 {
+  provider = aws.region1
+  ami = data.aws_ami.cassandra_r1.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r1_az1.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az1.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -20,7 +20,7 @@ resource "aws_instance" "i_cassandra_r1_i1" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -38,13 +38,13 @@ resource "aws_instance" "i_cassandra_r1_i1" {
   }
 }
 
-resource "aws_instance" "i_cassandra_r2_i1" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.cassandra_r2.id}"
+resource aws_instance i_cassandra_r2_i1 {
+  provider = aws.region2
+  ami = data.aws_ami.cassandra_r2.id
   instance_type = "m5.2xlarge"
-  subnet_id = "${aws_subnet.r2_az1.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r2.id}"]
+  subnet_id = aws_subnet.r2_az1.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r2.id]
   tags = {
     Name = "Demo - Cassandra Node",
     Purpose = "Demo failover"
@@ -56,7 +56,7 @@ resource "aws_instance" "i_cassandra_r2_i1" {
     delete_on_termination = true
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -68,7 +68,7 @@ resource "aws_instance" "i_cassandra_r2_i1" {
     inline = [
       "echo \"${self.private_ip} ${self.private_dns}\" | sudo tee -a /etc/hosts",
       "./generate_config.sh ${aws_instance.i_cassandra_r1_i1.private_ip},${aws_instance.i_cassandra_r2_i1.private_ip}",
-      "nohup ddac-*/bin/cassandra -p pid.txt &",
+      "nohup cassandra/bin/cassandra -p pid.txt &",
       "./wait_for_cassandra.sh"
     ]
   }

--- a/terraform/instances_client.tf
+++ b/terraform/instances_client.tf
@@ -2,20 +2,20 @@
 ### Load clients in Regions 1 and 2
 ##################################################
 
-resource "aws_instance" "client_r1" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.ami_client_r1.id}"
+resource aws_instance client_r1 {
+  provider = aws.region1
+  ami = data.aws_ami.ami_client_r1.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r1_az1.id}"
+  subnet_id = aws_subnet.r1_az1.id
   associate_public_ip_address = true
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_client_r1.id}"]
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_client_r1.id]
   tags = {
     Name = "Demo - Client",
     Purpose = "Demo failover"
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       host = self.public_ip
       type = "ssh"
@@ -30,20 +30,20 @@ resource "aws_instance" "client_r1" {
   }
 }
 
-resource "aws_instance" "client_r2" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.ami_client_r2.id}"
+resource aws_instance client_r2 {
+  provider = aws.region2
+  ami = data.aws_ami.ami_client_r2.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r2_az1.id}"
+  subnet_id = aws_subnet.r2_az1.id
   associate_public_ip_address = true
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_client_r2.id}"]
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_client_r2.id]
   tags = {
     Name = "Demo - Client",
     Purpose = "Demo failover"
   }
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       host = self.public_ip
       type = "ssh"

--- a/terraform/instances_web.tf
+++ b/terraform/instances_web.tf
@@ -1,10 +1,10 @@
-resource "aws_instance" "i_web_r1_i1" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.ami_web_r1.id}"
+resource aws_instance i_web_r1_i1 {
+  provider = aws.region1
+  ami = data.aws_ami.ami_web_r1.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r1_az1.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az1.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -13,7 +13,7 @@ resource "aws_instance" "i_web_r1_i1" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -29,13 +29,13 @@ resource "aws_instance" "i_web_r1_i1" {
   }
 }
 
-resource "aws_instance" "i_web_r1_i2" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.ami_web_r1.id}"
+resource aws_instance i_web_r1_i2 {
+  provider = aws.region1
+  ami = data.aws_ami.ami_web_r1.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r1_az2.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az2.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -44,7 +44,7 @@ resource "aws_instance" "i_web_r1_i2" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -60,13 +60,13 @@ resource "aws_instance" "i_web_r1_i2" {
   }
 }
 
-resource "aws_instance" "i_web_r1_i3" {
-  provider = "aws.region1"
-  ami = "${data.aws_ami.ami_web_r1.id}"
+resource aws_instance i_web_r1_i3 {
+  provider = aws.region1
+  ami = data.aws_ami.ami_web_r1.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r1_az3.id}"
-  key_name = "${aws_key_pair.key_r1.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r1.id}"]
+  subnet_id = aws_subnet.r1_az3.id
+  key_name = aws_key_pair.key_r1.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r1.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -75,7 +75,7 @@ resource "aws_instance" "i_web_r1_i3" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -91,13 +91,13 @@ resource "aws_instance" "i_web_r1_i3" {
   }
 }
 
-resource "aws_instance" "i_web_r2_i1" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.ami_web_r2.id}"
+resource aws_instance i_web_r2_i1 {
+  provider = aws.region2
+  ami = data.aws_ami.ami_web_r2.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r2_az1.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r2.id}"]
+  subnet_id = aws_subnet.r2_az1.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r2.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -106,7 +106,7 @@ resource "aws_instance" "i_web_r2_i1" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -122,13 +122,13 @@ resource "aws_instance" "i_web_r2_i1" {
   }
 }
 
-resource "aws_instance" "i_web_r2_i2" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.ami_web_r2.id}"
+resource aws_instance i_web_r2_i2 {
+  provider = aws.region2
+  ami = data.aws_ami.ami_web_r2.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r2_az2.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_default_r2.id}"]
+  subnet_id = aws_subnet.r2_az2.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_default_r2.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -137,7 +137,7 @@ resource "aws_instance" "i_web_r2_i2" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip
@@ -153,13 +153,13 @@ resource "aws_instance" "i_web_r2_i2" {
   }
 }
 
-resource "aws_instance" "i_web_r2_i3" {
-  provider = "aws.region2"
-  ami = "${data.aws_ami.ami_web_r2.id}"
+resource aws_instance i_web_r2_i3 {
+  provider = aws.region2
+  ami = data.aws_ami.ami_web_r2.id
   instance_type = "m5.large"
-  subnet_id = "${aws_subnet.r2_az3.id}"
-  key_name = "${aws_key_pair.key_r2.key_name}"
-  vpc_security_group_ids = ["${aws_security_group.sg_r2_az3.id}"]
+  subnet_id = aws_subnet.r2_az3.id
+  key_name = aws_key_pair.key_r2.key_name
+  vpc_security_group_ids = [aws_security_group.sg_r2_az3.id]
   tags = {
     Name = "Demo - Web",
     Purpose = "Demo failover"
@@ -168,7 +168,7 @@ resource "aws_instance" "i_web_r2_i3" {
   # Wait until the Cassandra/DSE nodes are available
   depends_on = [ aws_instance.i_cassandra_r1_i1 ]
 
-  provisioner "remote-exec" {
+  provisioner remote-exec {
     connection {
       bastion_host = aws_instance.bastion_r1.public_ip
       host = self.private_ip

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,38 +1,38 @@
-provider "aws" {
+provider aws {
   alias = "region1"
   region = var.region1
   version = "~> 2.16"
 }
 
-provider "aws" {
+provider aws {
   alias = "region2"
   region = var.region2
   version = "~> 2.16"
 }
 
-provider "aws" {
+provider aws {
   # Add a default one
   region = var.region1
 }
 
-provider "tls" {
+provider tls {
   version = "~> 2.0"
 }
 
-data "aws_availability_zones" "r1" {
-  provider = "aws.region1"
+data aws_availability_zones r1 {
+  provider = aws.region1
 }
 
-data "aws_availability_zones" "r2" {
-  provider = "aws.region2"
+data aws_availability_zones r2 {
+  provider = aws.region2
 }
 
-data "aws_caller_identity" "current" {
-  provider = "aws.region1"
+data aws_caller_identity current {
+  provider = aws.region1
 }
 
-data "aws_ami" "cassandra_r1" {
-  provider = "aws.region1"
+data aws_ami cassandra_r1 {
+  provider = aws.region1
   most_recent = true
   owners = ["self"]
   filter {
@@ -41,8 +41,8 @@ data "aws_ami" "cassandra_r1" {
   }
 }
 
-data "aws_ami" "cassandra_r2" {
-  provider = "aws.region2"
+data aws_ami cassandra_r2 {
+  provider = aws.region2
   most_recent = true
   owners = ["self"]
   filter {
@@ -51,8 +51,8 @@ data "aws_ami" "cassandra_r2" {
   }
 }
 
-data "aws_ami" "ami_web_r1" {
-  provider = "aws.region1"
+data aws_ami ami_web_r1 {
+  provider = aws.region1
   most_recent = true
   owners = ["self"]
   filter {
@@ -61,8 +61,8 @@ data "aws_ami" "ami_web_r1" {
   }
 }
 
-data "aws_ami" "ami_web_r2" {
-  provider = "aws.region2"
+data aws_ami ami_web_r2 {
+  provider = aws.region2
   most_recent = true
   owners = ["self"]
   filter {
@@ -71,8 +71,8 @@ data "aws_ami" "ami_web_r2" {
   }
 }
 
-data "aws_ami" "ami_client_r1" {
-  provider = "aws.region1"
+data aws_ami ami_client_r1 {
+  provider = aws.region1
   most_recent = true
   owners = ["self"]
   filter {
@@ -81,8 +81,8 @@ data "aws_ami" "ami_client_r1" {
   }
 }
 
-data "aws_ami" "ami_client_r2" {
-  provider = "aws.region2"
+data aws_ami ami_client_r2 {
+  provider = aws.region2
   most_recent = true
   owners = ["self"]
   filter {
@@ -91,23 +91,23 @@ data "aws_ami" "ami_client_r2" {
   }
 }
 
-resource "tls_private_key" "dev" {
+resource tls_private_key dev {
   algorithm = "RSA"
   rsa_bits  = 4096
 }
 
-resource "aws_key_pair" "key_r1" {
-  provider = "aws.region1"
+resource aws_key_pair key_r1 {
+  provider = aws.region1
   key_name   = "dev_key_r1"
-  public_key = "${tls_private_key.dev.public_key_openssh}"
+  public_key = tls_private_key.dev.public_key_openssh
 }
 
-resource "aws_key_pair" "key_r2" {
-  provider = "aws.region2"
+resource aws_key_pair key_r2 {
+  provider = aws.region2
   key_name   = "dev_key_r2"
-  public_key = "${tls_private_key.dev.public_key_openssh}"
+  public_key = tls_private_key.dev.public_key_openssh
 }
 
-resource "random_id" "id1" {
+resource random_id id1 {
   byte_length = 8
 }

--- a/terraform/security_groups.tf
+++ b/terraform/security_groups.tf
@@ -1,8 +1,8 @@
-resource "aws_security_group" "sg_default_r1" {
-  provider = "aws.region1"
+resource aws_security_group sg_default_r1 {
+  provider = aws.region1
   name        = "sg_demo_default_r1"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r1.id}"
+  vpc_id      = aws_vpc.r1.id
 
   # SSH, HTTP and more from the VPCs
   ingress {
@@ -21,11 +21,11 @@ resource "aws_security_group" "sg_default_r1" {
   }
 }
 
-resource "aws_security_group" "sg_default_r2" {
-  provider = "aws.region2"
+resource aws_security_group sg_default_r2 {
+  provider = aws.region2
   name        = "sg_demo_default_r2"
   description = "Used in the terraform demo region2"
-  vpc_id      = "${aws_vpc.r2.id}"
+  vpc_id      = aws_vpc.r2.id
 
   # outbound internet access
   egress {
@@ -36,11 +36,11 @@ resource "aws_security_group" "sg_default_r2" {
   }
 }
 
-resource "aws_security_group" "sg_r2_az3" {
-  provider = "aws.region2"
+resource aws_security_group sg_r2_az3 {
+  provider = aws.region2
   name        = "sg_demo_r2_az3"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r2.id}"
+  vpc_id      = aws_vpc.r2.id
 
   egress {
     from_port   = 0
@@ -50,11 +50,11 @@ resource "aws_security_group" "sg_r2_az3" {
   }
 }
 
-resource "aws_security_group" "sg_bastion_r1" {
-  provider = "aws.region1"
+resource aws_security_group sg_bastion_r1 {
+  provider = aws.region1
   name        = "sg_demo_bastion_r1"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r1.id}"
+  vpc_id      = aws_vpc.r1.id
 
   # SSH from the internet
   ingress {
@@ -65,11 +65,11 @@ resource "aws_security_group" "sg_bastion_r1" {
   }
 }
 
-resource "aws_security_group" "sg_client_r1" {
-  provider = "aws.region1"
+resource aws_security_group sg_client_r1 {
+  provider = aws.region1
   name        = "sg_demo_client_r1"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r1.id}"
+  vpc_id      = aws_vpc.r1.id
 
   # SSH from the internet
   ingress {
@@ -95,11 +95,11 @@ resource "aws_security_group" "sg_client_r1" {
   }
 }
 
-resource "aws_security_group" "sg_client_r2" {
-  provider = "aws.region2"
+resource aws_security_group sg_client_r2 {
+  provider = aws.region2
   name        = "sg_demo_client_r2"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r2.id}"
+  vpc_id      = aws_vpc.r2.id
 
   # SSH from the internet
   ingress {
@@ -125,11 +125,11 @@ resource "aws_security_group" "sg_client_r2" {
   }
 }
 
-resource "aws_security_group" "sg_elb_r1" {
-  provider = "aws.region1"
+resource aws_security_group sg_elb_r1 {
+  provider = aws.region1
   name        = "sg_elb_r1"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r1.id}"
+  vpc_id      = aws_vpc.r1.id
 
   ingress {
     from_port   = 80
@@ -146,11 +146,11 @@ resource "aws_security_group" "sg_elb_r1" {
   }
 }
 
-resource "aws_security_group" "sg_elb_r2" {
-  provider = "aws.region2"
+resource aws_security_group sg_elb_r2 {
+  provider = aws.region2
   name        = "sg_elb_r2"
   description = "Used in the terraform demo"
-  vpc_id      = "${aws_vpc.r2.id}"
+  vpc_id      = aws_vpc.r2.id
 
   egress {
     from_port = 0
@@ -161,34 +161,34 @@ resource "aws_security_group" "sg_elb_r2" {
 }
 
 # The following rule is created separately from the rest in order to allow to be removed in tests
-resource "aws_security_group_rule" "sg_rule_default_r2_allow_all_internal" {
-  provider = "aws.region2"
+resource aws_security_group_rule sg_rule_default_r2_allow_all_internal {
+  provider = aws.region2
   type = "ingress"
   from_port = 0
   to_port = 65535
   protocol = "tcp"
   cidr_blocks = ["10.0.0.0/8"]
-  security_group_id = "${aws_security_group.sg_default_r2.id}"
+  security_group_id = aws_security_group.sg_default_r2.id
 }
 
 # The following rule is created separately from the rest in order to allow to be removed in tests
-resource "aws_security_group_rule" "sg_rule_elb_r2_allow_http" {
-  provider = "aws.region2"
+resource aws_security_group_rule sg_rule_elb_r2_allow_http {
+  provider = aws.region2
   type = "ingress"
   from_port = 80
   to_port = 80
   protocol = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
-  security_group_id = "${aws_security_group.sg_elb_r2.id}"
+  security_group_id = aws_security_group.sg_elb_r2.id
 }
 
 # The following rule is created separately from the rest in order to allow to be dropped in simulations
-resource "aws_security_group_rule" "sg_rule_sg_r2_az3_allow_all_internal" {
-  provider = "aws.region2"
+resource aws_security_group_rule sg_rule_sg_r2_az3_allow_all_internal {
+  provider = aws.region2
   type = "ingress"
   from_port = 0
   to_port = 65535
   protocol = "tcp"
   cidr_blocks = ["10.0.0.0/8"]
-  security_group_id = "${aws_security_group.sg_r2_az3.id}"
+  security_group_id = aws_security_group.sg_r2_az3.id
 }

--- a/terraform/subnets.tf
+++ b/terraform/subnets.tf
@@ -1,41 +1,41 @@
-resource "aws_subnet" "r1_az1" {
-  provider = "aws.region1"
-  vpc_id = "${aws_vpc.r1.id}"
+resource aws_subnet r1_az1 {
+  provider = aws.region1
+  vpc_id = aws_vpc.r1.id
   cidr_block = "10.0.0.0/24"
-  availability_zone = "${data.aws_availability_zones.r1.names[0]}"
+  availability_zone = data.aws_availability_zones.r1.names[0]
 }
 
-resource "aws_subnet" "r1_az2" {
-  provider = "aws.region1"
-  vpc_id = "${aws_vpc.r1.id}"
+resource aws_subnet r1_az2 {
+  provider = aws.region1
+  vpc_id = aws_vpc.r1.id
   cidr_block = "10.0.1.0/24"
-  availability_zone = "${data.aws_availability_zones.r1.names[1]}"
+  availability_zone = data.aws_availability_zones.r1.names[1]
 }
 
-resource "aws_subnet" "r1_az3" {
-  provider = "aws.region1"
-  vpc_id = "${aws_vpc.r1.id}"
+resource aws_subnet r1_az3 {
+  provider = aws.region1
+  vpc_id = aws_vpc.r1.id
   cidr_block = "10.0.2.0/24"
-  availability_zone = "${data.aws_availability_zones.r1.names[2]}"
+  availability_zone = data.aws_availability_zones.r1.names[2]
 }
 
-resource "aws_subnet" "r2_az1" {
-  provider = "aws.region2"
-  vpc_id = "${aws_vpc.r2.id}"
+resource aws_subnet r2_az1 {
+  provider = aws.region2
+  vpc_id = aws_vpc.r2.id
   cidr_block = "10.1.0.0/24"
-  availability_zone = "${data.aws_availability_zones.r2.names[0]}"
+  availability_zone = data.aws_availability_zones.r2.names[0]
 }
 
-resource "aws_subnet" "r2_az2" {
-  provider = "aws.region2"
-  vpc_id = "${aws_vpc.r2.id}"
+resource aws_subnet r2_az2 {
+  provider = aws.region2
+  vpc_id = aws_vpc.r2.id
   cidr_block = "10.1.1.0/24"
-  availability_zone = "${data.aws_availability_zones.r2.names[1]}"
+  availability_zone = data.aws_availability_zones.r2.names[1]
 }
 
-resource "aws_subnet" "r2_az3" {
-  provider = "aws.region2"
-  vpc_id = "${aws_vpc.r2.id}"
+resource aws_subnet r2_az3 {
+  provider = aws.region2
+  vpc_id = aws_vpc.r2.id
   cidr_block = "10.1.2.0/24"
-  availability_zone = "${data.aws_availability_zones.r2.names[2]}"
+  availability_zone = data.aws_availability_zones.r2.names[2]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,13 +1,13 @@
-variable "region1" {
+variable region1 {
   default = "us-east-1"
 }
 
-variable "region2" {
+variable region2 {
   default = "us-west-2"
 }
 
-variable "amis" {
-  type = "map"
+variable amis {
+  type = map
   default = {
     "us-east-1" = "ami-b374d5a5"
     "us-west-2" = "ami-4b32be2b"

--- a/terraform/vpcs.tf
+++ b/terraform/vpcs.tf
@@ -2,8 +2,8 @@
 ### VPCs, VPC peering, route tables and internet gateway
 ########################################################
 
-resource "aws_vpc" "r1" {
-  provider = "aws.region1"
+resource aws_vpc r1 {
+  provider = aws.region1
   cidr_block = "10.0.0.0/16"
   enable_dns_hostnames = true
   tags = {
@@ -12,8 +12,8 @@ resource "aws_vpc" "r1" {
   }
 }
 
-resource "aws_vpc" "r2" {
-  provider = "aws.region2"
+resource aws_vpc r2 {
+  provider = aws.region2
   cidr_block = "10.1.0.0/16"
   enable_dns_hostnames = true
   tags = {
@@ -22,61 +22,61 @@ resource "aws_vpc" "r2" {
   }
 }
 
-resource "aws_internet_gateway" "agw_r1" {
-  provider = "aws.region1"
-  vpc_id = "${aws_vpc.r1.id}"
+resource aws_internet_gateway agw_r1 {
+  provider = aws.region1
+  vpc_id = aws_vpc.r1.id
   tags = {
     Name = "Demo - IG R1",
     Purpose = "Demo failover"
   }
 }
 
-resource "aws_route" "internet_access_r1" {
-  provider = "aws.region1"
-  route_table_id         = "${aws_vpc.r1.main_route_table_id}"
+resource aws_route internet_access_r1 {
+  provider = aws.region1
+  route_table_id         = aws_vpc.r1.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.agw_r1.id}"
+  gateway_id             = aws_internet_gateway.agw_r1.id
 }
 
-resource "aws_internet_gateway" "agw_r2" {
-  provider = "aws.region2"
-  vpc_id = "${aws_vpc.r2.id}"
+resource aws_internet_gateway agw_r2 {
+  provider = aws.region2
+  vpc_id = aws_vpc.r2.id
   tags = { Name = "demo" }
 }
 
-resource "aws_route" "internet_access_r2" {
-  provider = "aws.region2"
-  route_table_id         = "${aws_vpc.r2.main_route_table_id}"
+resource aws_route internet_access_r2 {
+  provider = aws.region2
+  route_table_id         = aws_vpc.r2.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
-  gateway_id             = "${aws_internet_gateway.agw_r2.id}"
+  gateway_id             = aws_internet_gateway.agw_r2.id
 }
 
-resource "aws_vpc_peering_connection" "r1_to_r2_requester" {
-  provider = "aws.region1"
-  vpc_id        = "${aws_vpc.r1.id}"
-  peer_vpc_id   = "${aws_vpc.r2.id}"
+resource aws_vpc_peering_connection r1_to_r2_requester {
+  provider = aws.region1
+  vpc_id        = aws_vpc.r1.id
+  peer_vpc_id   = aws_vpc.r2.id
   peer_region   = var.region2
   auto_accept   = false
   tags = { Side = "Requester" }
 }
 
-resource "aws_vpc_peering_connection_accepter" "r1_to_r2_accepter" {
-  provider = "aws.region2"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.r1_to_r2_requester.id}"
+resource aws_vpc_peering_connection_accepter r1_to_r2_accepter {
+  provider = aws.region2
+  vpc_peering_connection_id = aws_vpc_peering_connection.r1_to_r2_requester.id
   auto_accept = true
   tags = { Side = "Accepter" }
 }
 
-resource "aws_route" "route_r1" {
-  provider = "aws.region1"
-  route_table_id            = "${aws_vpc.r1.main_route_table_id}"
+resource aws_route route_r1 {
+  provider = aws.region1
+  route_table_id            = aws_vpc.r1.main_route_table_id
   destination_cidr_block    = "10.1.0.0/16"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.r1_to_r2_requester.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection.r1_to_r2_requester.id
 }
 
-resource "aws_route" "route_r2" {
-  provider = "aws.region2"
-  route_table_id            = "${aws_vpc.r2.main_route_table_id}"
+resource aws_route route_r2 {
+  provider = aws.region2
+  route_table_id            = aws_vpc.r2.main_route_table_id
   destination_cidr_block    = "10.0.0.0/16"
-  vpc_peering_connection_id = "${aws_vpc_peering_connection.r1_to_r2_requester.id}"
+  vpc_peering_connection_id = aws_vpc_peering_connection.r1_to_r2_requester.id
 }


### PR DESCRIPTION
This PR changes the DDAC references to Cassandra and uses the latest C* 4.0-alpha build.

The terraform file changes are to remove the deprecation warnings that show when using quotes for resource names with terraform version 0.12+